### PR TITLE
refactor: add logger and mask token

### DIFF
--- a/src/api/validator.ts
+++ b/src/api/validator.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosResponse } from "axios";
 import { ValidateError } from "../types";
+import { logger } from "@/logger";
 
 export const validator = async (
   token: string,
@@ -8,7 +9,11 @@ export const validator = async (
   invalid: (validateError: ValidateError) => void,
   error: (reason: any) => void
 ) => {
-  console.log(`validator token=${token},body=${JSON.stringify(body)}`);
+  const maskToken = (t: string) =>
+    t ? `${t.slice(0, 4)}****${t.slice(-4)}` : "";
+  logger.debug(
+    `validator token=${maskToken(token)},body=${JSON.stringify(body)}`
+  );
   const headers = {
     "Content-Type": "application/json",
     Authorization: `Bearer ${token}`,
@@ -21,7 +26,7 @@ export const validator = async (
       success(response);
     })
     .catch((reason) => {
-      console.log(reason);
+      logger.error(reason);
       if (!!reason && !!reason.response && !!reason.response.data) {
         const validateError: ValidateError = reason.response.data;
         invalid(validateError);

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,16 @@
+export type LogLevel = "debug" | "error" | "silent";
+
+const logLevel: LogLevel = (process.env.LOG_LEVEL as LogLevel) || "error";
+
+export const logger = {
+  debug: (...args: unknown[]) => {
+    if (logLevel === "debug") {
+      console.debug(...args);
+    }
+  },
+  error: (...args: unknown[]) => {
+    if (logLevel !== "silent") {
+      console.error(...args);
+    }
+  },
+};


### PR DESCRIPTION
## Summary
- remove direct console logging in validator
- add configurable logger with token masking

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68abcf47b8dc832d8395be4dfe1d857e