### PR TITLE
Handle JSON parse errors in form submission

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -12,9 +12,16 @@ export default function Home() {
 
   const onSubmit = handleSubmit(async (data) => {
     await chrome.storage.local.set(data);
+    let body;
+    try {
+      body = JSON.parse(data.body);
+    } catch (error) {
+      setResult(error instanceof Error ? error.message : String(error));
+      return;
+    }
     await validator(
       data.token,
-      JSON.parse(data.body),
+      body,
       () => setResult("Success!"),
       (validateError) => setResult(JSON.stringify(validateError, null, 2)),
       (_) => setResult("unknown error")


### PR DESCRIPTION
## Summary
- ensure form JSON parsing is wrapped in try/catch
- return early and show error message when JSON is invalid

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abcf482b00832d8671321714034434