### PR TITLE
Make result textarea read-only

### DIFF
--- a/src/components/Form/index.tsx
+++ b/src/components/Form/index.tsx
@@ -46,8 +46,8 @@ export default function Form({
           {!!errors.body && "messages(JSON) is required"}
         </FormErrorMessage>
       </FormControl>
-      <FormLabel>result</FormLabel>
-      <Textarea value={result} h="100" />
+      <FormLabel>result (read-only)</FormLabel>
+      <Textarea value={result} h="100" isReadOnly bg="gray.100" />
       <Button
         mt={2}
         bg="#4299E1"


### PR DESCRIPTION
## Summary
- Make result display textarea read-only and visually distinct

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abcf4ae590832daa34925808421577