### PR TITLE
Limit host permissions to LINE reply validation endpoint

### DIFF
--- a/extensions/manifest.json
+++ b/extensions/manifest.json
@@ -8,5 +8,5 @@
     "default_popup": "./dist/index.html"
   },
   "permissions": ["storage"],
-  "host_permissions": ["https://api.line.me/v2/bot/message/validate/*"]
+  "host_permissions": ["https://api.line.me/v2/bot/message/validate/reply"]
 }


### PR DESCRIPTION
## Summary
- restrict host_permissions in manifest to `https://api.line.me/v2/bot/message/validate/reply`

## Testing
- `npm test` *(fails: npm not found)*
- `npm run build` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abcf4c18a8832d990f07706e83817b