### PR TITLE
use session storage for tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,13 @@ First, run the development server:
 yarn install
 yarn dev
 ```
+
+## Token Handling
+
+Tokens used by the validator are sensitive credentials.  To reduce the risk of
+unintended exposure, the application stores the token only in
+`chrome.storage.session`, which keeps data in memory for the duration of the
+extension session and is cleared when the extension closes.  Tokens are never
+persisted to disk.  The message body is still saved in `chrome.storage.local`
+for convenience.  Users should avoid sharing tokens and should enter them again
+for each new session.

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -11,7 +11,8 @@ export default function Home() {
   const { register, setValue, handleSubmit, formState } = useForm<FormData>();
 
   const onSubmit = handleSubmit(async (data) => {
-    await chrome.storage.local.set(data);
+    await chrome.storage.local.set({ body: data.body });
+    await chrome.storage.session.set({ token: data.token });
     await validator(
       data.token,
       JSON.parse(data.body),
@@ -22,11 +23,13 @@ export default function Home() {
   });
 
   useEffect(() => {
-    chrome.storage.local.get(["token", "body"], (items) => {
-      const data = items as FormData;
-      const body = data && data.body ? data.body : placeholder;
-      setValue("token", data.token);
+    chrome.storage.local.remove("token");
+    chrome.storage.local.get(["body"], (items) => {
+      const body = items && items.body ? items.body : placeholder;
       setValue("body", body);
+    });
+    chrome.storage.session.get(["token"], (items) => {
+      if (items.token) setValue("token", items.token);
     });
   }, [setValue]);
 


### PR DESCRIPTION
## Summary
- store tokens in session storage instead of persisting to disk
- document token handling policy

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68abcf4caf20832d9b19ff6d957088b0