### PR TITLE
Add timeout handling for validator API requests

### DIFF
--- a/src/api/validator.spec.ts
+++ b/src/api/validator.spec.ts
@@ -21,4 +21,21 @@ describe("validator", () => {
       }
     );
   });
+  test("timeout", async () => {
+    expect.assertions(1);
+    axiosMock.post.mockRejectedValue({ code: "ECONNABORTED" });
+    await validator(
+      "token",
+      "body",
+      () => {
+        expect(true).toBe(false);
+      },
+      () => {
+        expect(true).toBe(false);
+      },
+      (reason) => {
+        expect(reason).toBe("Request timed out. Please try again later.");
+      }
+    );
+  });
 });

--- a/src/api/validator.ts
+++ b/src/api/validator.ts
@@ -16,13 +16,16 @@ export const validator = async (
   await axios
     .post("https://api.line.me/v2/bot/message/validate/reply", body, {
       headers: headers,
+      timeout: 5000,
     })
     .then((response) => {
       success(response);
     })
     .catch((reason) => {
       console.log(reason);
-      if (!!reason && !!reason.response && !!reason.response.data) {
+      if (reason.code === "ECONNABORTED") {
+        error("Request timed out. Please try again later.");
+      } else if (!!reason && !!reason.response && !!reason.response.data) {
         const validateError: ValidateError = reason.response.data;
         invalid(validateError);
       } else {


### PR DESCRIPTION
## Summary
- add 5-second timeout to validator API request
- return user-friendly error when request times out
- test timeout handling

## Testing
- `npm run lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68abcf4e4648832da4084294e266ac13