### PR TITLE
feat: broaden validator body type

### DIFF
--- a/src/api/validator.spec.ts
+++ b/src/api/validator.spec.ts
@@ -9,7 +9,7 @@ describe("validator", () => {
     axiosMock.post.mockResolvedValue({});
     await validator(
       "token",
-      "body",
+      {},
       () => {
         expect(true).toBe(true);
       },

--- a/src/api/validator.ts
+++ b/src/api/validator.ts
@@ -3,7 +3,7 @@ import { ValidateError } from "../types";
 
 export const validator = async (
   token: string,
-  body: string,
+  body: unknown,
   success: (response: AxiosResponse) => void,
   invalid: (validateError: ValidateError) => void,
   error: (reason: any) => void

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -14,7 +14,7 @@ export default function Home() {
     await chrome.storage.local.set(data);
     await validator(
       data.token,
-      JSON.parse(data.body),
+      JSON.parse(data.body) as unknown,
       () => setResult("Success!"),
       (validateError) => setResult(JSON.stringify(validateError, null, 2)),
       (_) => setResult("unknown error")


### PR DESCRIPTION
## Summary
- allow validator to accept unknown payloads
- adjust page and tests for new validator body type

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68abcf4d4c44832da58b81a5a322467f