### PR TITLE
Enable automerge for minor and patch updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,14 @@
   },
   "packageRules": [
     {
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "automerge": true,
+      "platformAutomerge": true
+    },
+    {
       "groupName": "linters",
       "extends": [
         "packages:linters"


### PR DESCRIPTION
## 関連Issus
<!-- close #1-->

## 変更点
- renovate.json に新しいパッケージルールを追加
- minor と patch の更新に対して自動マージを有効化
- `automerge` と `platformAutomerge` を true に設定

## その他
- なし

https://claude.ai/code/session_01MhaT2pBsFHUdkCquzbph7d