### PR TITLE
fix: bot が作った PR の CI が承認待ちで止まるのを直す

### DIFF
--- a/.github/workflows/create_pr_main_to_develop.yml
+++ b/.github/workflows/create_pr_main_to_develop.yml
@@ -25,15 +25,9 @@ jobs:
       - name: Push Branch
         run: git push origin merge/gha_${{ env.CURRENT_DATETIME }}
 
-      - name: Install Hub
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y hub
-
       - name: Create Pull Request
         env:
-          REVIEWERS: "tokku5552"
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.AUTOMATION_PAT }}
           BRANCH_NAME: merge/gha_${{ env.CURRENT_DATETIME }}
         run: |
-          hub pull-request -m "[bot(create_pr_main_to_develop)]: created at ${{ env.CURRENT_DATETIME }}" -b develop -h $BRANCH_NAME  -r "$REVIEWERS"
+          gh pr create --title "[bot(create_pr_main_to_develop)]: created at ${{ env.CURRENT_DATETIME }}" --body "" --base develop --head "$BRANCH_NAME"

--- a/.github/workflows/create_release_pr.yml
+++ b/.github/workflows/create_release_pr.yml
@@ -24,15 +24,9 @@ jobs:
       - name: Push Branch
         run: git push origin release/gha_${{ env.CURRENT_DATETIME }}
 
-      - name: Install Hub
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y hub
-
       - name: Create Pull Request
         env:
-          REVIEWERS: "tokku5552"
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.AUTOMATION_PAT }}
           BRANCH_NAME: release/gha_${{ env.CURRENT_DATETIME }}
         run: |
-          hub pull-request -m "[bot(create_release_pr)]: created at ${{ env.CURRENT_DATETIME }}" -b main -h $BRANCH_NAME  -r "$REVIEWERS"
+          gh pr create --title "[bot(create_release_pr)]: created at ${{ env.CURRENT_DATETIME }}" --body "" --base main --head "$BRANCH_NAME"


### PR DESCRIPTION
create_release_pr / create_pr_main_to_develop の PR 作成トークンを GITHUB_TOKEN から AUTOMATION_PAT に変更し、bot 作者だと CI が
action_required で承認待ちになる問題を解消する。あわせて deprecated な
hub pull-request を gh pr create に移行し、Install Hub ステップと レビュアー指定を削除する。


Claude-Session: https://claude.ai/code/session_01JpvSVmTNf7cM3g4iM8iRYT

## 関連Issus
<!-- close #1-->

## 変更点
- 変更した点

## その他
- なし